### PR TITLE
Leave main-header z-index=1001 to prevent overlapping objects

### DIFF
--- a/theme/static/assets/css/surface.css
+++ b/theme/static/assets/css/surface.css
@@ -2,9 +2,6 @@ html, body, .wrapper {
     height: 100%;
 }
 
-.main-header {
-  z-index: 2;
-}
 #search-nav {
     max-width: 60% !important;
     width: 60% !important;


### PR DESCRIPTION
Leave main-header z-index 1001 to prevent other objects overlapping over the header/search bar like this:
![image](https://user-images.githubusercontent.com/91122533/173850311-68df5472-0347-463a-943a-65824b1124a9.png)

Will use the z-index from atlantis:
https://github.com/surface-security/django-surface-theme/blob/main/theme/static/assets/css/atlantis.css#L293
